### PR TITLE
User Restrictions By Role

### DIFF
--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -39,6 +39,7 @@ namespace TabloidMVC.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, userProfile.Id.ToString()),
                 new Claim(ClaimTypes.Email, userProfile.Email),
+                new Claim(ClaimTypes.Role, userProfile.UserType.Name)
             };
 
             var claimsIdentity = new ClaimsIdentity(

--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -48,6 +48,7 @@ namespace TabloidMVC.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, registeredUser.Id.ToString()),
                 new Claim(ClaimTypes.Email, registeredUser.Email),
+                new Claim(ClaimTypes.Role, registeredUser.UserType.Name)
             };
 
                 var claimsIdentity = new ClaimsIdentity(

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -10,8 +10,8 @@ using TabloidMVC.Models;
 using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
-{   
-    [Authorize]
+{
+    [Authorize(Roles = "Admin")]
     public class CategoryController : Controller
     {
         private readonly CategoryRepository _catRepo;

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -137,7 +137,7 @@ namespace TabloidMVC.Controllers
             string UsersRole = GetCurrentUserRole();
             if (UsersRole == "Author" && post.UserProfileId != currentUserId)
             {
-                RedirectToAction("Index");
+                return RedirectToAction("Index");
             }
 
             return View(post);

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -26,8 +26,11 @@ namespace TabloidMVC.Controllers
 
         public IActionResult Index()
         {
-            var posts = _postRepository.GetAllPublishedPosts();
-            return View(posts);
+            var vm = new PostIndexViewModel();
+            vm.Posts = _postRepository.GetAllPublishedPosts();
+            vm.UserId = GetCurrentUserProfileId();
+            vm.PostModel = new Post();
+            return View(vm);
         }
 
         public IActionResult Details(int id)
@@ -43,7 +46,10 @@ namespace TabloidMVC.Controllers
                 }
             }
             post.Tags = _postTagRepo.GetPostTags(id);
-            return View(post);
+            var vm = new PostIndexViewModel();
+            vm.PostModel = post;
+            vm.UserId = GetCurrentUserProfileId();
+            return View(vm);
         }
 
         public IActionResult Create()

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -83,8 +83,7 @@ namespace TabloidMVC.Controllers
         {
             var vm = new PostCreateViewModel();
             vm.CategoryOptions = _categoryRepository.GetAll();
-            int userId = GetCurrentUserProfileId();
-            var post = _postRepository.GetUserPostById(id, userId);
+            var post = _postRepository.GetPostById(id);
             vm.Post = post;
 
             if (post == null)
@@ -121,7 +120,7 @@ namespace TabloidMVC.Controllers
         public ActionResult Delete(int id)
         {
             int userId = GetCurrentUserProfileId();
-            var post = _postRepository.GetUserPostById(id, userId);
+            var post = _postRepository.GetPostById(id);
 
             if (post == null)
             {

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -91,6 +91,13 @@ namespace TabloidMVC.Controllers
                 return RedirectToAction("Index");
             }
 
+            int currentUserId = GetCurrentUserProfileId();
+            string UsersRole = GetCurrentUserRole();
+            if(UsersRole == "Author" && post.UserProfileId != currentUserId)
+            {
+                RedirectToAction("Index");
+            }
+
             return View(vm);
         }
 
@@ -119,12 +126,18 @@ namespace TabloidMVC.Controllers
 
         public ActionResult Delete(int id)
         {
-            int userId = GetCurrentUserProfileId();
             var post = _postRepository.GetPostById(id);
 
             if (post == null)
             {
                 return RedirectToAction("Index");
+            }
+
+            int currentUserId = GetCurrentUserProfileId();
+            string UsersRole = GetCurrentUserRole();
+            if (UsersRole == "Author" && post.UserProfileId != currentUserId)
+            {
+                RedirectToAction("Index");
             }
 
             return View(post);
@@ -146,7 +159,10 @@ namespace TabloidMVC.Controllers
                 return View(post);
             }
         }
-
+        private string GetCurrentUserRole()
+        {
+            return User.FindFirstValue(ClaimTypes.Role);
+        }
     }
 
 }

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -95,7 +95,7 @@ namespace TabloidMVC.Controllers
             string UsersRole = GetCurrentUserRole();
             if(UsersRole == "Author" && post.UserProfileId != currentUserId)
             {
-                RedirectToAction("Index");
+                return RedirectToAction("Index");
             }
 
             return View(vm);

--- a/TabloidMVC/Controllers/PostTagController.cs
+++ b/TabloidMVC/Controllers/PostTagController.cs
@@ -45,7 +45,7 @@ namespace TabloidMVC.Controllers
             string UsersRole = GetCurrentUserRole();
             if (UsersRole == "Author" && post.UserProfileId != currentUserId)
             {
-                RedirectToAction("Index", "MyPosts");
+                return RedirectToAction("Index", "MyPosts");
             }
 
             List<Tag> postTags = _postTagRepo.GetPostTags(id); //list of all tags for this particular post

--- a/TabloidMVC/Controllers/PostTagController.cs
+++ b/TabloidMVC/Controllers/PostTagController.cs
@@ -41,6 +41,13 @@ namespace TabloidMVC.Controllers
                 return RedirectToAction("Index", "MyPosts");
             }
 
+            int currentUserId = GetCurrentUserProfileId();
+            string UsersRole = GetCurrentUserRole();
+            if (UsersRole == "Author" && post.UserProfileId != currentUserId)
+            {
+                RedirectToAction("Index", "MyPosts");
+            }
+
             List<Tag> postTags = _postTagRepo.GetPostTags(id); //list of all tags for this particular post
             vm.Tags = postTags;
             
@@ -98,6 +105,10 @@ namespace TabloidMVC.Controllers
         {
             string id = User.FindFirstValue(ClaimTypes.NameIdentifier);
             return int.Parse(id);
+        }
+        private string GetCurrentUserRole()
+        {
+            return User.FindFirstValue(ClaimTypes.Role);
         }
     }
 

--- a/TabloidMVC/Controllers/TagsController.cs
+++ b/TabloidMVC/Controllers/TagsController.cs
@@ -11,7 +11,7 @@ using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
 {
-    [Authorize]
+    [Authorize(Roles = "Admin")]
     public class TagsController : Controller
     {
         private readonly TagRepository _tagRepo;

--- a/TabloidMVC/Controllers/UsersController.cs
+++ b/TabloidMVC/Controllers/UsersController.cs
@@ -12,7 +12,7 @@ using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
 {
-    [Authorize]
+    [Authorize(Roles = "Admin")]
     public class UsersController : Controller
     {
         private readonly UserProfileRepository _userRepo;

--- a/TabloidMVC/Models/ViewModels/PostIndexViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/PostIndexViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models.ViewModels
+{
+    public class PostIndexViewModel
+    {
+        public List<Post> Posts { get; set; }
+        public int UserId { get; set; }
+        public Post PostModel { get; set; }
+    }
+}

--- a/TabloidMVC/TabloidMVC.csproj
+++ b/TabloidMVC/TabloidMVC.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.5" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -1,62 +1,70 @@
-﻿@model TabloidMVC.Models.Post
+﻿@model TabloidMVC.Models.ViewModels.PostIndexViewModel
 
 @{
-    ViewData["Title"] = $"Post - {Model.Title}";
+    ViewData["Title"] = $"Post - {Model.PostModel.Title}";
+}
+@{
+    bool IsAdmin()
+    {
+        return (User.IsInRole("Admin")) ? true : false;
+    }
 }
 
-    <div class="container pt-5">
-        <div class="post">
-            <section class="px-3">
-                <div class="row justify-content-between">
-                    <h1 class="text-secondary">@Model.Title</h1>
-                    <h1 class="text-black-50">@Model.Category.Name</h1>
-                </div>
-                <div class="row justify-content-between">
-                    <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
-                    <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
-                </div>
+<div class="container pt-5">
+    <div class="post">
+        <section class="px-3">
+            <div class="row justify-content-between">
+                <h1 class="text-secondary">@Model.PostModel.Title</h1>
+                <h1 class="text-black-50">@Model.PostModel.Category.Name</h1>
+            </div>
+            <div class="row justify-content-between">
+                <p class="text-secondary">Written by @Model.PostModel.UserProfile.DisplayName</p>
+                <p class="text-black-50">Published on @Html.DisplayFor(model => model.PostModel.PublishDateTime)</p>
+            </div>
+            @if (IsAdmin() || Model.UserId == Model.PostModel.UserProfileId)
+            {
                 <div class="row">
-                    <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                    <a asp-action="Edit" asp-route-id="@Model.PostModel.Id" class="btn btn-outline-primary mx-1" title="Edit">
                         <i class="fas fa-pencil-alt"></i>
                     </a>
-                    <a asp-controller="PostTag" asp-action="Manage" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Manage Tags">
+                    <a asp-controller="PostTag" asp-action="Manage" asp-route-id="@Model.PostModel.Id" class="btn btn-outline-primary mx-1" title="Manage Tags">
                         <svg class="bi bi-tag-fill" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                             <path fill-rule="evenodd" d="M2 1a1 1 0 0 0-1 1v4.586a1 1 0 0 0 .293.707l7 7a1 1 0 0 0 1.414 0l4.586-4.586a1 1 0 0 0 0-1.414l-7-7A1 1 0 0 0 6.586 1H2zm4 3.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
                         </svg>
                     </a>
-                    <a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                    <a asp-action="Delete" asp-route-id="@Model.PostModel.Id" class="btn btn-outline-primary mx-1" title="Delete">
                         <i class="fas fa-trash"></i>
                     </a>
                 </div>
-
-            </section>
-
-            @if (@Model.Tags.Count() > 0)
-            {
-                <hr />
-                <section class="d-flex justify-content-lg-start wrap">
-                    <h4 class="badge p-2 mr-2">Tags</h4>
-                    @foreach (Tag tag in @Model.Tags)
-                    {
-                        <h4 class="badge badge-primary p-2 mr-2">@tag.Name</h4>
-                    }
-                </section>
             }
+        </section>
 
+        @if (@Model.PostModel.Tags.Count() > 0)
+        {
             <hr />
-            @if (!string.IsNullOrWhiteSpace(Model.ImageLocation))
-            {
-                <section class="row justify-content-center">
-                    <div>
-                        <img src="@Model.ImageLocation" />
-                    </div>
-                </section>
-            }
-            <section class="row">
-                <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.Content)</p>
+            <section class="d-flex justify-content-lg-start wrap">
+                <h4 class="badge p-2 mr-2">Tags</h4>
+                @foreach (Tag tag in @Model.PostModel.Tags)
+                {
+                    <h4 class="badge badge-primary p-2 mr-2">@tag.Name</h4>
+                }
             </section>
-        </div>
-        <div>
-            <a asp-action="Index">Back to List</a>
-        </div>
+        }
+
+        <hr />
+        @if (!string.IsNullOrWhiteSpace(Model.PostModel.ImageLocation))
+        {
+            <section class="row justify-content-center">
+                <div>
+                    <img src="@Model.PostModel.ImageLocation" />
+                </div>
+            </section>
+        }
+        <section class="row">
+            <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.PostModel.Content)</p>
+        </section>
     </div>
+    <div>
+        <a asp-action="Index">Back to List</a>
+    </div>
+</div>

--- a/TabloidMVC/Views/Post/Index.cshtml
+++ b/TabloidMVC/Views/Post/Index.cshtml
@@ -1,9 +1,15 @@
-﻿@model IEnumerable<TabloidMVC.Models.Post>
+﻿@model TabloidMVC.Models.ViewModels.PostIndexViewModel
 
 @{
     ViewData["Title"] = "Index";
 }
 
+@{ 
+    bool IsAdmin()
+    {
+        return (User.IsInRole("Admin")) ? true : false;
+    }
+}
 
 <div class="container pt-5">
     <h1>Posts</h1>
@@ -15,22 +21,22 @@
         <thead>
             <tr>
                 <th>
-                    @Html.DisplayNameFor(model => model.Title)
+                    @Html.DisplayNameFor(model => model.PostModel.Title)
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.UserProfileId)
+                    @Html.DisplayNameFor(model => model.PostModel.UserProfileId)
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.CategoryId)
+                    @Html.DisplayNameFor(model => model.PostModel.CategoryId)
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.PublishDateTime)
+                    @Html.DisplayNameFor(model => model.PostModel.PublishDateTime)
                 </th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
-            @foreach (var item in Model)
+            @foreach (var item in Model.Posts)
             {
                 <tr>
                     <td>
@@ -49,12 +55,15 @@
                         <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="View">
                             <i class="fas fa-eye"></i>
                         </a>
-                        <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
-                            <i class="fas fa-pencil-alt"></i>
-                        </a>
-                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
-                            <i class="fas fa-trash"></i>
-                        </a>
+                        @if (IsAdmin() || Model.UserId == item.UserProfileId)
+                        {
+                            <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                                <i class="fas fa-pencil-alt"></i>
+                            </a>
+                            <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                                <i class="fas fa-trash"></i>
+                            </a>
+                        }
                     </td>
                 </tr>
             }

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -33,15 +33,18 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="MyPosts" asp-action="Index">MY POSTS</a>
                             </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORIES</a>
-                            </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Users" asp-action="Index">USERS</a>
-                            </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tags" asp-action="Index">TAGS</a>
-                            </li>
+                            @if (User.IsInRole("Admin"))
+                            {
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORIES</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Users" asp-action="Index">USERS</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tags" asp-action="Index">TAGS</a>
+                                </li>
+                            }
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
                             </li>


### PR DESCRIPTION
### Changes
- Added Roles to ClaimsIdentity
- Restricted Author's access to User, Tags, and Category Tabs as well as editing and deleting posts that are not their own
### To Test
- Ensure that you cannot see those tabs as an Author
- Ensure you can still edit your own posts as an author
- Ensure you can see tags but not manage them as author
- Everything should work the same as an admin